### PR TITLE
refactor(docker-compose): remove container names for n8n services

### DIFF
--- a/blueprints/n8n-runner-postgres-ollama/docker-compose.yml
+++ b/blueprints/n8n-runner-postgres-ollama/docker-compose.yml
@@ -57,7 +57,6 @@ services:
 
   n8n-worker:
     image: docker.n8n.io/n8nio/n8n:latest
-    container_name: n8n-worker
     restart: always
     command: worker
     environment:
@@ -85,7 +84,6 @@ services:
 
   n8n-runner:
     image: n8nio/runners:nightly
-    container_name: n8n-runner
     restart: always
     environment:
       - N8N_RUNNERS_TASK_BROKER_URI=http://n8n:5679
@@ -98,14 +96,12 @@ services:
 
   ollama:
     image: ollama/ollama:latest
-    container_name: ollama
     restart: unless-stopped
     volumes:
       - ollama_storage:/home/node/.ollama
       
   init-ollama:
     image: ollama/ollama:latest
-    container_name: ollama-pull
     volumes:
       - ollama_storage:/home/node/.ollama
     entrypoint: /bin/sh
@@ -117,7 +113,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: redis
     restart: unless-stopped
     command: redis-server --appendonly yes
     healthcheck:
@@ -130,7 +125,6 @@ services:
       
   postgres:
     image: postgres:17-alpine
-    container_name: dokploy-postgres
     hostname: postgres
     restart: unless-stopped
     environment:


### PR DESCRIPTION
This pull request makes a series of small updates to the `docker-compose.yml` file for the `n8n-runner-postgres-ollama` blueprint. The main change is the removal of explicit `container_name` assignments from all service definitions, which allows Docker Compose to use its default naming convention and can help avoid naming conflicts when running multiple instances.

Container configuration cleanup:

* Removed the `container_name` field from the following services: `n8n-worker`, `n8n-runner`, `ollama`, `init-ollama`, `redis`, and `postgres` in `blueprints/n8n-runner-postgres-ollama/docker-compose.yml`. [[1]](diffhunk://#diff-bb80e098e7922a962d0535ac562afdd301c8ace1b5a06811b748b419ba712a7bL60) [[2]](diffhunk://#diff-bb80e098e7922a962d0535ac562afdd301c8ace1b5a06811b748b419ba712a7bL88) [[3]](diffhunk://#diff-bb80e098e7922a962d0535ac562afdd301c8ace1b5a06811b748b419ba712a7bL101-L108) [[4]](diffhunk://#diff-bb80e098e7922a962d0535ac562afdd301c8ace1b5a06811b748b419ba712a7bL120) [[5]](diffhunk://#diff-bb80e098e7922a962d0535ac562afdd301c8ace1b5a06811b748b419ba712a7bL133)